### PR TITLE
fix gcc15 warnings

### DIFF
--- a/libuuid/src/unparse.c
+++ b/libuuid/src/unparse.c
@@ -37,8 +37,8 @@
 
 #include "uuidP.h"
 
-static char const hexdigits_lower[16] = "0123456789abcdef";
-static char const hexdigits_upper[16] = "0123456789ABCDEF";
+static char const hexdigits_lower[] = "0123456789abcdef";
+static char const hexdigits_upper[] = "0123456789ABCDEF";
 
 static void uuid_fmt(const uuid_t uuid, char *buf, char const *restrict fmt)
 {


### PR DESCRIPTION
gcc15 complains that the string is too long, indeed it is not counting the last null byte, fix by simply not using an explicit len.